### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/io.github.giantpinkrobots.flatsweep.json
+++ b/io.github.giantpinkrobots.flatsweep.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.giantpinkrobots.flatsweep",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "flatsweep",
     "finish-args" : [


### PR DESCRIPTION
GNOME runtime version 46 will reach EOL on 2025-03-15.

Source: https://release.gnome.org/calendar/